### PR TITLE
Enhance lain enter and support lain attach

### DIFF
--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/lain_cli/attach.py
+++ b/lain_cli/attach.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 from argh.decorators import arg
 from entryclient import EntryClient
-from lain_sdk.util import error
+from lain_sdk.util import error, info
 from lain_cli.auth import SSOAccess, authorize_and_check
 from lain_cli.utils import check_phase, lain_yaml, get_domain
 
-import os
-
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def enter(phase, proc_name, instance_no):
+def attach(phase, proc_name, instance_no):
     """
     enter the container of specific proc
     """
@@ -19,16 +17,16 @@ def enter(phase, proc_name, instance_no):
     authorize_and_check(phase, yml.appname)
     domain = get_domain(phase)
     access_token = SSOAccess.get_token(phase)
-
-    term_type = os.environ.get("TERM", "xterm")
-    endpoint = "wss://entry.%s/enter" % domain
+    endpoint = "wss://entry.%s/attach" % domain
     header_data = ["access-token: %s" % access_token,
                    "app-name: %s" % yml.appname,
                    "proc-name: %s" % proc_name,
-                   "instance-no: %s" % instance_no,
-                   "term-type: %s" % term_type]
+                   "instance-no: %s" % instance_no]
     try:
         client = EntryClient(endpoint, header=header_data)
-        client.invoke_shell()
+        info("Start to attach the stdout/stderr of the container. Press <Ctrl+c> to stop...")
+        client.attach_container()
+    except KeyboardInterrupt:
+        pass
     except:
         error("Server stops the connection. Ask admin for help.")

--- a/lain_cli/attach.py
+++ b/lain_cli/attach.py
@@ -7,19 +7,21 @@ from lain_cli.utils import check_phase, lain_yaml, get_domain
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def attach(phase, proc_name, instance_no):
+@arg('-t', '--target', help='The target appname to attach, if not set, will be the appname of the working dir')
+def attach(phase, proc_name, instance_no, target=None):
     """
     enter the container of specific proc
     """
 
     check_phase(phase)
     yml = lain_yaml(ignore_prepare=True)
-    authorize_and_check(phase, yml.appname)
+    appname = target if target else yml.appname
+    authorize_and_check(phase, appname)
     domain = get_domain(phase)
     access_token = SSOAccess.get_token(phase)
     endpoint = "wss://entry.%s/attach" % domain
     header_data = ["access-token: %s" % access_token,
-                   "app-name: %s" % yml.appname,
+                   "app-name: %s" % appname,
                    "proc-name: %s" % proc_name,
                    "instance-no: %s" % instance_no]
     try:

--- a/lain_cli/enter.py
+++ b/lain_cli/enter.py
@@ -9,21 +9,23 @@ import os
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def enter(phase, proc_name, instance_no):
+@arg('-t', '--target', help='The target appname to enter. If it\'s not set, it will be the appname of the working dir')
+def enter(phase, proc_name, instance_no, target=None):
     """
     enter the container of specific proc
     """
 
     check_phase(phase)
     yml = lain_yaml(ignore_prepare=True)
-    authorize_and_check(phase, yml.appname)
+    appname = target if target else yml.appname
+    authorize_and_check(phase, appname)
     domain = get_domain(phase)
     access_token = SSOAccess.get_token(phase)
 
     term_type = os.environ.get("TERM", "xterm")
     endpoint = "wss://entry.%s/enter" % domain
     header_data = ["access-token: %s" % access_token,
-                   "app-name: %s" % yml.appname,
+                   "app-name: %s" % appname,
                    "proc-name: %s" % proc_name,
                    "instance-no: %s" % instance_no,
                    "term-type: %s" % term_type]

--- a/lain_cli/lain.py
+++ b/lain_cli/lain.py
@@ -3,6 +3,7 @@
 import logging
 import argh
 
+from lain_cli.attach import attach
 from lain_cli.dashboard import dashboard
 from lain_cli.reposit import reposit
 from lain_cli.prepare import prepare
@@ -43,7 +44,7 @@ logging.getLogger("docker").setLevel(logging.WARNING)
 
 
 one_level_commands = [
-    dashboard, reposit, prepare, build, tag,
+    attach, dashboard, reposit, prepare, build, tag,
     push, deploy, ps, validate, appversion,
     prepare_update, rmi, scale,
     check, meta, undeploy, enter,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     'requests==2.6.0',
     'tabulate==0.7.5',
     'protobuf==3.0.0b3',
-    'entryclient==2.0.0',
+    'entryclient==2.1.0',
 ]
 
 setup(
@@ -32,5 +32,5 @@ setup(
     include_package_data=True,
     entry_points=ENTRY_POINTS,
     install_requires=requirements,
-    dependency_links=['https://github.com/laincloud/entry/archive/master.zip#egg=entryclient-2.0.0'],
+    dependency_links=['https://github.com/laincloud/entry/archive/2.1.0.zip#egg=entryclient-2.1.0'],
 )


### PR DESCRIPTION
Updates:
- Add a new subcommand `attach`: Client can attach the stdout/stderr of process 1 of the container.
- Add `-t` parameter support to `lain enter` and `lain attach` to target an appname.