### PR TITLE
fix `lain scale -o` 不起作用

### DIFF
--- a/lain_cli/scale.py
+++ b/lain_cli/scale.py
@@ -6,7 +6,7 @@ import pprint
 from argh.decorators import arg
 
 from lain_sdk.util import error, warn, info
-from lain_cli.utils import check_phase, lain_yaml, get_domain, render_proc_status
+from lain_cli.utils import check_phase, lain_yaml, get_domain, render_proc_status, get_apptype
 from lain_cli.auth import SSOAccess, authorize_and_check, get_auth_header
 
 
@@ -18,7 +18,7 @@ def scale(phase, proc, target=None, cpu=None, memory=None, numinstances=None, ou
     """
     Scale proc with cpu/memory/num_instances
     """
-    
+
     check_phase(phase)
     yml = lain_yaml(ignore_prepare=True)
     appname = target if target else yml.appname
@@ -142,7 +142,6 @@ def render_scale_result(scale_result, output):
         msg = result.pop('msg', '')
         if msg:
             print msg.decode('string_escape')
-        info("proc status: ")
-        render_proc_status(result.get('proc'), output=output)
-    except Exception:
+        render_proc_status(result.get('proc'), get_apptype(), output=output)
+    except Exception as e:
         pprint.pprint(scale_result.content)

--- a/lain_cli/scale.py
+++ b/lain_cli/scale.py
@@ -142,6 +142,7 @@ def render_scale_result(scale_result, output):
         msg = result.pop('msg', '')
         if msg:
             print msg.decode('string_escape')
+        info("proc status: ")
         render_proc_status(result.get('proc'), get_apptype(), output=output)
-    except Exception as e:
+    except Exception:
         pprint.pprint(scale_result.content)


### PR DESCRIPTION
# 起因

`lain scale -o` 不起作用，没有了美化效果。

# 经过

发现是因为 `render_proc_status` 函数调用时少了 `apptype` 的参数，导致进入**异常**处理，使用 `pprint.pprint` 打印，而非 `tabulate` 或 `json.dumps`。所以我给 `render_proc_status` 加了 `apptype` 参数~

# 结果

+ `lain scale -n 3 -o pretty local web` 成功；
+ `lain scale -n 3 -o json local web` 成功；
+ `lain scale -n 3 -o json-pretty local web` 成功。