### PR TITLE
[fix] lain push 失败，但是还是 exit 0

### DIFF
--- a/lain_cli/push.py
+++ b/lain_cli/push.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 from argh.decorators import arg
 
 from lain_sdk.util import error, info
@@ -27,6 +28,6 @@ def push(phase):
     release_code = docker.push(phase_release_tag)
     if meta_code or release_code:
         error("Error lain push.")
+        sys.exit(1)
     else:
         info("Done lain push.")
-    

--- a/lain_cli/utils.py
+++ b/lain_cli/utils.py
@@ -326,4 +326,4 @@ def is_resource_instance(appname):
 
 def exit_gracefully(signal, frame):
     warn("You pressed Ctrl + C, and I will exit...")
-    sys.exit(0)
+    sys.exit(130)


### PR DESCRIPTION
# 起因

`lain push` 失败了但是还是 `exit 0` 。

# 经过

+ 当发生错误时，调用 `sys.exit(1)` 退出；
+ 修正 `Ctrl + C` 的 `exit code` 为 [130](http://tldp.org/LDP/abs/html/exitcodes.html)。

# 结果

`lain push` 失败时 `exit code` 为 1。