### PR TITLE
add meta version when lain build

### DIFF
--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.0.5'
+__version__ = '2.1.0'

--- a/lain_cli/build.py
+++ b/lain_cli/build.py
@@ -32,10 +32,8 @@ def build(push=False, release=False):
             error("need git commit SHA1.")
             return None
         tag_release_name = yml.tag_meta_version(release_name)
-        docker.tag(release_name, tag_release_name)
         docker.push(tag_release_name)
 
         tag_meta_name = yml.tag_meta_version(meta_name)
-        docker.tag(meta_name, tag_meta_name)
         docker.push(tag_meta_name)
     info("Done lain build.")

--- a/lain_cli/tag.py
+++ b/lain_cli/tag.py
@@ -21,8 +21,8 @@ def tag(phase):
         return None
     domain = get_domain(phase)
     registry = "registry.%s" % domain
-    meta_tag = "%s:meta" % (yml.appname, )
-    release_tag = "%s:release" % (yml.appname, )
+    meta_tag = "%s:meta-%s" % (yml.appname, meta_version)
+    release_tag = "%s:release-%s" % (yml.appname, meta_version)
     phase_meta_tag = docker.gen_image_name(yml.appname, 'meta', meta_version, registry)
     phase_release_tag = docker.gen_image_name(yml.appname, 'release', meta_version, registry)
     meta_code = docker.tag(meta_tag, phase_meta_tag)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ requirements = [
     'tabulate==0.7.5',
     'protobuf==3.0.0b3',
     'entryclient==2.2.0',
-    'lain-sdk==2.2.2',
+    'lain-sdk==2.3.0',
 ]
 
 setup(
@@ -35,6 +35,6 @@ setup(
     install_requires=requirements,
     dependency_links=[
         'https://github.com/laincloud/entry/archive/v2.2.0.zip#egg=entryclient-2.2.0',
-        'https://github.com/laincloud/lain-sdk/archive/v2.2.2.zip#egg=lain-sdk-2.2.2',
+        'https://github.com/laincloud/lain-sdk/archive/v2.3.0.zip#egg=lain-sdk-2.3.0',
     ],
 )


### PR DESCRIPTION
## 起因

在同一台机器上对同一个 LAIN 应用的不同分支进行 lain build 时，两个分支产生的镜像均为 ${appname}:build、 ${appname}:meta、 ${appname}:release，相互之间会覆盖，引起之后的 lain tag 的混淆，所以在 lain build 时加了 meta version，即 ${git-commit-timestamp}-${git-commit-id}。

> - 比如在 Jenkins 上会存在上述场景。
> - 与 [lain-sdk 的这个 PR](https://github.com/laincloud/lain-sdk/pull/14) 一起更改。

## 测试

- `lain build` 产生 `${appname}:(build/copy_inter/release/meta)-${git-commit-timestamp}-${git-commit-id}`
- `lain build --release` 产生 `${appname}:(copy_inter/release/meta)-${git-commit-timestamp}-${git-commit-id}`
- `lain build --push` 产生 `${appname}:(build/copy_inter/release/meta)-${git-commit-timestamp}-${git-commit-id}` 和 `${private_docker_registry}/${appname}:(release/meta)-${git-commit-timestamp}-${git-commit-id}`
- `lain tag ${LAIN-cluster}` 会把 `${appname}:release/meta)-${git-commit-timestamp}-${git-commit-id}` 打标签为 `registry.${LAIN-domain}/${appname}:(release/meta)-${git-commit-timestamp}-${git-commit-id}`
- `lain push` 会推送 `registry.${LAIN-domain}/${appname}:(release/meta)-${git-commit-timestamp}-${git-commit-id}`
- `lain test` 会产生 `${appname}:(build/test)-${git-commit-timestamp}-${git-commit-id}`