### PR TITLE
rm useless dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,27 @@
 CLI 是用户使用 LAIN 平台的入口工具。用户对自己应用的部署，升级，查看等操作都要通过 CLI。
 
 CLI 相关命令文档可以在 [LAIN White Paper](https://laincloud.gitbooks.io/white-paper/content/usermanual/sdkandcli.html) 中查看。
+
+## 安装
+
+```
+pip install lain-cli
+```
+
+## 打包上传到 PyPI
+
+### 依赖
+
+```
+pip install twine  # 上传工具
+pip install wheel  # 打包工具
+```
+
+### 打包上传
+
+```
+rm -rf dist/  # 清空以前的构建
+python setup.py sdist  # 打包源代码
+python setup.py bdist_wheel  # 构建 wheel
+twine upload dist/*  # 上传
+```

--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'

--- a/setup.py
+++ b/setup.py
@@ -8,22 +8,13 @@ lain = lain_cli.lain:main
 """
 
 requirements = [
-    'Jinja2==2.7.3',
     'PyYAML==3.11',
     'argh==0.26.1',
-    'argcomplete==0.9.0',
-    'six==1.9.0',
-    'websocket-client==0.32.0',
-    'retrying==1.3.3',
-    'docker-py==1.7.2',
     'humanfriendly==1.29',
-    'paramiko==1.15.2',
-    'gevent==1.0.2',
     'requests==2.6.0',
     'tabulate==0.7.5',
-    'protobuf==3.0.0b3',
-    'entryclient==2.2.0',
-    'lain-sdk==2.3.0',
+    'entryclient==2.3.0',
+    'lain-sdk==2.3.1',
 ]
 
 setup(
@@ -33,8 +24,4 @@ setup(
     include_package_data=True,
     entry_points=ENTRY_POINTS,
     install_requires=requirements,
-    dependency_links=[
-        'https://github.com/laincloud/entry/archive/v2.2.0.zip#egg=entryclient-2.2.0',
-        'https://github.com/laincloud/lain-sdk/archive/v2.3.0.zip#egg=lain-sdk-2.3.0',
-    ],
 )


### PR DESCRIPTION
## 起因

lain-cli 现在有一些没有用到的依赖，安装时容易引起冲突，所以需要把这些依赖去掉。

## 测试

- `lain appversion dev` 成功
- `lain attach dev web 1` 成功
- `lain build` 成功
- `lain build --release` 成功
- `lain build --push` 成功
- `lain check dev` 成功
- `lain clear` 成功
- `lain clear --without build,prepare` 成功
- `lain dashboard dev` 成功
- `lain dashboard -s state dev` 成功
- `lain debug web` 成功
- `lain deploy dev` 成功
- `lain enter dev web 1` 成功
- `lain login dev` 成功
- `lain logout dev` 成功
- `lain meta` 成功
- `lain prepare` 成功
- `lain prepare-update` 成功
- `lain ps dev` 成功
- `lain push dev` 成功
- `lain refresh dev` 成功
- `lain reposit dev` 成功
- `lain rm web` 成功
- `lain rmi dev` 成功
- `lain run web` 成功
- `lain scale -n 2 dev web` 成功
- `lain stop web` 成功
- `lain tag dev` 成功
- `lain test` 成功
- `lain undeploy dev` 成功
- `lain update` 成功
- `lain validate` 成功
- `lain version` 成功
- `lain config show` 成功
- `lain secret show dev web` 成功
- `lain maintainer show dev` 成功