### PR TITLE
update lain-sdk version to replace docker-py with docker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'requests==2.6.0',
     'tabulate==0.7.5',
     'entryclient==2.3.0',
-    'lain-sdk==2.3.1',
+    'lain-sdk==2.3.2',
 ]
 
 setup(


### PR DESCRIPTION
因为[在 macOS 上 `lain build` 出错](https://github.com/laincloud/lain-cli/issues/25)，所以升级了 lain-sdk，详情请参考[lain-sdk 的 pr](https://github.com/laincloud/lain-sdk/pull/19)。