### PR TITLE
add --config argument

### DIFF
--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.1.2'
+__version__ = '2.1.3'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'requests==2.6.0',
     'tabulate==0.7.5',
     'entryclient==2.3.0',
-    'lain-sdk==2.3.2',
+    'lain-sdk==2.3.3',
 ]
 
 setup(


### PR DESCRIPTION
## 起因

目前 lain-cli 使用 `./lain.yaml` 作为配置文件，然后可以通过 `LAIN_DOMAIN` 控制在不同集群下的行为。但这种方式存在一定的局限性：
- 开发者可能习惯于为不同的集群指定不同的配置文件，并不了解 `LAIN_DOMAIN` 这个环境变量
- 比如一个 maven 工程，必须编译两次（`mvn clean package -Pprod && mv /lain/app/target/demo.war /lain/app/demo-prod.war` 和 `mvn clean package -Pdev && mv /lain/app/target/demo.war /lain/app/demo-dev.war`），然后在 entry.sh 里指定要运行的 war 文件，而编译可能需要花不少时间
- 比如在测试环境里使用了 mysql-service，但生产环境直接用物理机上的 mysql，不使用 service 机制，`LAIN_DOMAIN` 无法做到这个层面的控制

使用不同的配置文件可以让开发者更容易理解，也更灵活

## 经过

在继续使用 `./lain.yaml` 作为默认配置文件的同时，也提供 `--config` 选项，让开发者可以自己指定配置文件。

## 结果

- `lain build -c lain-dev.yaml` 成功
- `lain tag dev` 成功
- `lain push dev` 成功
- `lain deploy dev` 成功