### PR TITLE
add --config argument

### DIFF
--- a/lain_cli/__init__.py
+++ b/lain_cli/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = '2.1.3'
+__version__ = '2.2.0'

--- a/lain_cli/build.py
+++ b/lain_cli/build.py
@@ -4,20 +4,21 @@ from argh.decorators import arg
 
 import lain_sdk.mydocker as docker
 from lain_sdk.util import error, warn, info
-from lain_cli.utils import lain_yaml
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 from lain_cli.validate import validate_only_warning
 
 
 @arg('--release', help="build from build image if it exists")
 @arg('--push',    help="tag release and meta image with version and push to registry")
-def build(push=False, release=False):
+@arg('-c', '--config', help="the configuration file path")
+def build(push=False, release=False, config=LAIN_YAML_PATH):
     """
     Build release and meta images
     """
 
     info("Building meta and release images ...")
-    validate_only_warning()
-    yml = lain_yaml()
+    validate_only_warning(config)
+    yml = lain_yaml(config)
     meta_version = yml.repo_meta_version()
     use_prepare = docker.exist(yml.img_names['prepare'])
     use_build = release and docker.exist(yml.img_names['build'])

--- a/lain_cli/deploy.py
+++ b/lain_cli/deploy.py
@@ -11,6 +11,7 @@ from lain_cli.auth import SSOAccess, authorize_and_check, get_auth_header
 from lain_cli.utils import check_phase, get_domain, lain_yaml, is_resource_instance
 from lain_cli.utils import reposit_app, get_version_lists, get_app_state
 from lain_cli.utils import render_app_status, render_proc_status
+from lain_cli.utils import LAIN_YAML_PATH
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
@@ -18,13 +19,14 @@ from lain_cli.utils import render_app_status, render_proc_status
 @arg('-t', '--target', help='The target app to deploy, if not set, will be the appname of the working dir')
 @arg('-p', '--proc', help='The proc need to deploy, should not be used with argh -v')
 @arg('-o', '--output', choices=['pretty', 'json', 'json-pretty'], default='pretty')
-def deploy(phase, version=None, target=None, proc=None, output='pretty'):
+@arg('-c', '--config', help="the configuration file path")
+def deploy(phase, version=None, target=None, proc=None, output='pretty', config=LAIN_YAML_PATH):
     """
     Deploy specific proc in the app or the whole app
     """
 
     check_phase(phase)
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     appname = target if target else yml.appname
     authorize_and_check(phase, appname)
 

--- a/lain_cli/enter.py
+++ b/lain_cli/enter.py
@@ -3,20 +3,21 @@ from argh.decorators import arg
 from entryclient import EntryClient
 from lain_sdk.util import error
 from lain_cli.auth import SSOAccess, authorize_and_check
-from lain_cli.utils import check_phase, lain_yaml, get_domain
+from lain_cli.utils import check_phase, lain_yaml, get_domain, LAIN_YAML_PATH
 
 import os
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
 @arg('-t', '--target', help='The target appname to enter. If it\'s not set, it will be the appname of the working dir')
-def enter(phase, proc_name, instance_no, target=None):
+@arg('-c', '--config', help="the configuration file path")
+def enter(phase, proc_name, instance_no, target=None, config=LAIN_YAML_PATH):
     """
     Enter the container of specific proc
     """
 
     check_phase(phase)
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     appname = target if target else yml.appname
     authorize_and_check(phase, appname)
     domain = get_domain(phase)

--- a/lain_cli/imagecheck.py
+++ b/lain_cli/imagecheck.py
@@ -3,11 +3,11 @@ from argh.decorators import arg
 
 import lain_sdk.mydocker as docker
 from lain_sdk.util import error, info
-from lain_cli.utils import lain_yaml, check_phase, get_domain
+from lain_cli.utils import lain_yaml, check_phase, get_domain, LAIN_YAML_PATH
 
 
-def _check_phase_tag(phase):
-    yml = lain_yaml(ignore_prepare=True)
+def _check_phase_tag(phase, config):
+    yml = lain_yaml(config, ignore_prepare=True)
     meta_version = yml.repo_meta_version()
     if meta_version is None:
         error("please git commit.")
@@ -32,13 +32,14 @@ def _check_phase_tag(phase):
 
 
 @arg('phase', help="lain phase, can be added by lain config save")
-def check(phase):    
+@arg('-c', '--config', help="the configuration file path")
+def check(phase, config=LAIN_YAML_PATH):
     """
     Check current version of release and meta images in the remote registry
     """
 
     check_phase(phase)
-    tag_ok = _check_phase_tag(phase)
+    tag_ok = _check_phase_tag(phase, config)
     if tag_ok:
         info("Image Tag OK in registry")
     else:

--- a/lain_cli/maintainer.py
+++ b/lain_cli/maintainer.py
@@ -5,7 +5,8 @@ from argh.decorators import arg
 
 from lain_sdk.util import info, error
 from lain_cli.auth import SSOAccess, get_auth_header, authorize_and_check
-from lain_cli.utils import TwoLevelCommandBase, check_phase, get_domain, lain_yaml
+from lain_cli.utils import TwoLevelCommandBase, check_phase, get_domain
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 
 
 class MaintainerCommands(TwoLevelCommandBase):
@@ -27,7 +28,8 @@ class MaintainerCommands(TwoLevelCommandBase):
 
     @classmethod
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
-    def show(cls, phase, username=None):
+    @arg('-c', '--config', help="the configuration file path")
+    def show(cls, phase, username=None, config=LAIN_YAML_PATH):
         """
         show maintainers list or specical maitainer message of app in different phase
 
@@ -35,7 +37,7 @@ class MaintainerCommands(TwoLevelCommandBase):
         """
         
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         console = "console.%s" % get_domain(phase)
@@ -56,13 +58,14 @@ class MaintainerCommands(TwoLevelCommandBase):
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
     @arg('username', help="sso username to add")
     @arg('role', help='role to assigned to the user', choices=['admin', 'normal'])
-    def add(cls, phase, username, role):
+    @arg('-c', '--config', help="the configuration file path")
+    def add(cls, phase, username, role, config=LAIN_YAML_PATH):
         """
         add maintianer for different phase
         """
         
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         console = "console.%s" % get_domain(phase)
@@ -81,13 +84,14 @@ class MaintainerCommands(TwoLevelCommandBase):
     @classmethod
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
     @arg('username', help="sso username")
-    def delete(cls, phase, username):
+    @arg('-c', '--config', help="the configuration file path")
+    def delete(cls, phase, username, config=LAIN_YAML_PATH):
         """
         delete maintianer for different phase
         """
 
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         console = "console.%s" % get_domain(phase)

--- a/lain_cli/meta.py
+++ b/lain_cli/meta.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
+from argh.decorators import arg
+
 from lain_sdk.util import error, info
-from lain_cli.utils import lain_yaml
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 
 
-def meta():
+@arg('-c', '--config', help="the configuration file path")
+def meta(config=LAIN_YAML_PATH):
     """
     Show current meta version
     """
 
-    meta_version = lain_yaml(ignore_prepare=True).repo_meta_version()
+    meta_version = lain_yaml(config, ignore_prepare=True).repo_meta_version()
     if meta_version is None:
         error("please git commit.")
     else:

--- a/lain_cli/prepare.py
+++ b/lain_cli/prepare.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 import sys
+from argh.decorators import arg
 
 from lain_sdk.util import info, error
-from lain_cli.utils import lain_yaml
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 from lain_cli.validate import validate_only_warning
 
 
-def prepare():
+@arg('-c', '--config', help="the configuration file path")
+def prepare(config=LAIN_YAML_PATH):
     """
     Build prepare image
     """
 
-    validate_only_warning()
+    validate_only_warning(config)
     info("Generating prepare image...")
-    if not lain_yaml().build_prepare()[0]:
+    if not lain_yaml(config).build_prepare()[0]:
         error("Error lain prepare.")
         sys.exit(1)
     else:

--- a/lain_cli/prepare_update.py
+++ b/lain_cli/prepare_update.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 import sys
+from argh.decorators import arg
 
-from lain_cli.utils import lain_yaml
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 from lain_cli.validate import validate_only_warning
 
 
-def prepare_update():
+@arg('-c', '--config', help="the configuration file path")
+def prepare_update(config=LAIN_YAML_PATH):
     """
     Update prepare image based on existed prepare image
     """
 
-    validate_only_warning()
-    if not lain_yaml().update_prepare()[0]:
+    validate_only_warning(config)
+    if not lain_yaml(config).update_prepare()[0]:
         sys.exit(1)
     else:
         sys.exit(0)

--- a/lain_cli/ps.py
+++ b/lain_cli/ps.py
@@ -6,18 +6,19 @@ from argh.decorators import arg
 from lain_sdk.util import error
 from lain_cli.auth import SSOAccess, get_auth_header, authorize_and_check
 from lain_cli.utils import check_phase, get_domain, lain_yaml
-from lain_cli.utils import render_app_status
+from lain_cli.utils import render_app_status, LAIN_YAML_PATH
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
 @arg('-o', '--output', choices=['pretty', 'json', 'json-pretty'], default='pretty')
-def ps(phase, output='pretty'):
+@arg('-c', '--config', help="the configuration file path")
+def ps(phase, output='pretty', config=LAIN_YAML_PATH):
     """
     Show basic deploy messages of app
     """
 
     check_phase(phase)
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     authorize_and_check(phase, yml.appname)
     console = "console.%s" % get_domain(phase)
 

--- a/lain_cli/push.py
+++ b/lain_cli/push.py
@@ -4,18 +4,19 @@ from argh.decorators import arg
 
 from lain_sdk.util import error, info
 import lain_sdk.mydocker as docker
-from lain_cli.utils import check_phase, lain_yaml, get_domain
+from lain_cli.utils import check_phase, lain_yaml, get_domain, LAIN_YAML_PATH
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def push(phase):
+@arg('-c', '--config', help="the configuration file path")
+def push(phase, config=LAIN_YAML_PATH):
     """
     Push release and meta images
     """
 
     check_phase(phase)
     info("Pushing meta and release images ...")
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     meta_version = yml.repo_meta_version()
     if meta_version is None:
         error("please git commit.")

--- a/lain_cli/reposit.py
+++ b/lain_cli/reposit.py
@@ -3,21 +3,22 @@ from argh.decorators import arg
 
 from lain_sdk.util import info
 from lain_cli.auth import SSOAccess, get_auth_header, authorize_and_check
-from lain_cli.utils import check_phase, lain_yaml, reposit_app, get_domain
+from lain_cli.utils import check_phase, lain_yaml, reposit_app, get_domain, LAIN_YAML_PATH
 from lain_cli.validate import validate_only_warning
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def reposit(phase):
+@arg('-c', '--config', help="the configuration file path")
+def reposit(phase, config=LAIN_YAML_PATH):
     """
     Initialize a repository in lain
     """
 
     check_phase(phase)
-    validate_only_warning()
+    validate_only_warning(config)
     info("Repositing ...")
 
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     authorize_and_check(phase, yml.appname)
 
     access_token = SSOAccess.get_token(phase)

--- a/lain_cli/rmi.py
+++ b/lain_cli/rmi.py
@@ -4,10 +4,11 @@ from argh.decorators import arg
 import lain_sdk.mydocker as docker
 from lain_cli.utils import check_phase
 from lain_cli.utils import lain_yaml, get_meta_versions_from_tags, get_domain
+from lain_cli.utils import LAIN_YAML_PATH
 
 
-def get_repo_tags_to_remove(phase):
-    yml = lain_yaml(ignore_prepare=True)
+def get_repo_tags_to_remove(phase, config):
+    yml = lain_yaml(config, ignore_prepare=True)
     domain = get_domain(phase)
     registry = "registry.%s" % domain
     all_tags = docker.get_tag_list_in_docker_daemon(registry, yml.appname)
@@ -27,12 +28,13 @@ def get_repo_tags_to_remove(phase):
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def rmi(phase):
+@arg('-c', '--config', help="the configuration file path")
+def rmi(phase, config=LAIN_YAML_PATH):
     """
     Remove app images in the local host
     """
 
     check_phase(phase)
-    repo_tags = get_repo_tags_to_remove(phase)
+    repo_tags = get_repo_tags_to_remove(phase, config)
     for image in repo_tags:
         docker.remove_image(image)

--- a/lain_cli/run.py
+++ b/lain_cli/run.py
@@ -6,14 +6,14 @@ from argh.decorators import arg
 import lain_sdk.mydocker as docker
 from lain_sdk.util import error, info
 from lain_sdk.yaml.conf import DOCKER_APP_ROOT
-from lain_cli.utils import lain_yaml
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 
 
 LOCAL_VOLUME_BASE = "/tmp/lain/run"
 
 
-def gen_run_ctx(proc_name):
-    yml = lain_yaml(ignore_prepare=True)
+def gen_run_ctx(proc_name, config):
+    yml = lain_yaml(config, ignore_prepare=True)
     proc = yml.procs.get(proc_name, None)
     if proc is None:
         error('proc {} does not exist'.format(proc_name))
@@ -44,12 +44,13 @@ def gen_run_ctx(proc_name):
 
 
 @arg('proc_name')
-def run(proc_name):
+@arg('-c', '--config', help="the configuration file path")
+def run(proc_name, config=LAIN_YAML_PATH):
     """
     Run proc instance in the local host
     """
 
-    container_name, image, working_dir, port, cmd, envs, volumes, _ = gen_run_ctx(proc_name)
+    container_name, image, working_dir, port, cmd, envs, volumes, _ = gen_run_ctx(proc_name, config)
     docker.proc_run(container_name, image, working_dir, port, cmd, envs, volumes)
     info("container name: {}".format(container_name))
     if port:
@@ -57,12 +58,13 @@ def run(proc_name):
 
 
 @arg('proc_name')
-def debug(proc_name):
+@arg('-c', '--config', help="the configuration file path")
+def debug(proc_name, config=LAIN_YAML_PATH):
     """
     Debug proc instance in the local host
     """
 
-    container_name, _, _, _, _, _, _, _ = gen_run_ctx(proc_name)
+    container_name, _, _, _, _, _, _, _ = gen_run_ctx(proc_name, config)
     docker.proc_debug(container_name)
 
 

--- a/lain_cli/scale.py
+++ b/lain_cli/scale.py
@@ -6,7 +6,7 @@ import pprint
 from argh.decorators import arg
 
 from lain_sdk.util import error, warn, info
-from lain_cli.utils import check_phase, lain_yaml, get_domain, render_proc_status, get_apptype
+from lain_cli.utils import check_phase, lain_yaml, get_domain, render_proc_status, get_apptype, LAIN_YAML_PATH
 from lain_cli.auth import SSOAccess, authorize_and_check, get_auth_header
 
 
@@ -14,13 +14,14 @@ from lain_cli.auth import SSOAccess, authorize_and_check, get_auth_header
 @arg('proc', help="proc name")
 @arg('-t', '--target', help='The target app to deploy, if not set, will be the appname of the working dir')
 @arg('-o', '--output', choices=['pretty', 'json', 'json-pretty'], default='pretty')
-def scale(phase, proc, target=None, cpu=None, memory=None, numinstances=None, output='pretty'):
+@arg('--config', help="the configuration file path")
+def scale(phase, proc, target=None, cpu=None, memory=None, numinstances=None, output='pretty', config=LAIN_YAML_PATH):
     """
     Scale proc with cpu/memory/num_instances
     """
 
     check_phase(phase)
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     appname = target if target else yml.appname
     authorize_and_check(phase, appname)
 
@@ -74,7 +75,7 @@ def scale(phase, proc, target=None, cpu=None, memory=None, numinstances=None, ou
             'payload': payload1,
             'success': scale_r.status_code < 300
         }
-        render_scale_result(scale_r, output)
+        render_scale_result(scale_r, output, config)
 
     if numinstances is not None:
         payload2['num_instances'] = numinstances
@@ -87,7 +88,7 @@ def scale(phase, proc, target=None, cpu=None, memory=None, numinstances=None, ou
             'payload': payload2,
             'success': scale_r.status_code < 300
         }
-        render_scale_result(scale_r, output)
+        render_scale_result(scale_r, output, config)
 
     info("Outline of scale result: ")
     for k, v in scale_results.iteritems():
@@ -136,13 +137,13 @@ def validate_parameters(cpu, memory, numinstances):
     return cpu, memory, numinstances
 
 
-def render_scale_result(scale_result, output):
+def render_scale_result(scale_result, output, config):
     try:
         result = scale_result.json()
         msg = result.pop('msg', '')
         if msg:
             print msg.decode('string_escape')
         info("proc status: ")
-        render_proc_status(result.get('proc'), get_apptype(), output=output)
+        render_proc_status(result.get('proc'), get_apptype(config), output=output)
     except Exception:
         pprint.pprint(scale_result.content)

--- a/lain_cli/secret.py
+++ b/lain_cli/secret.py
@@ -6,7 +6,7 @@ from argh.decorators import arg
 from lain_sdk.util import info, error
 from lain_cli.auth import SSOAccess, get_auth_header, authorize_and_check
 from lain_cli.utils import TwoLevelCommandBase, check_phase
-from lain_cli.utils import lain_yaml, get_domain
+from lain_cli.utils import lain_yaml, get_domain, LAIN_YAML_PATH
 
 class SecretCommands(TwoLevelCommandBase):
     '''
@@ -29,7 +29,8 @@ class SecretCommands(TwoLevelCommandBase):
     @classmethod
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
     @arg('procname', help="proc name of the app")
-    def show(cls, phase, procname, path=None):
+    @arg('-c', '--config', help="the configuration file path")
+    def show(cls, phase, procname, path=None, config=LAIN_YAML_PATH):
         """
         show secret file of special procname in different phase
 
@@ -37,7 +38,7 @@ class SecretCommands(TwoLevelCommandBase):
         """
 
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         proc = yml.procs.get(procname, None)
@@ -62,7 +63,8 @@ class SecretCommands(TwoLevelCommandBase):
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
     @arg('procname', help="proc name of the app")
     @arg('path', help='absolute path of config file, eg : /lain/app/config')
-    def add(cls, phase, procname, path, content=None, file=None):
+    @arg('--config', help="the configuration file path")
+    def add(cls, phase, procname, path, content=None, file=None, config=LAIN_YAML_PATH):
         """
         add secret file for different phase
 
@@ -83,7 +85,7 @@ class SecretCommands(TwoLevelCommandBase):
                 exit(1)
 
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         proc = yml.procs.get(procname, None)
@@ -106,13 +108,14 @@ class SecretCommands(TwoLevelCommandBase):
     @arg('phase', help="lain cluster phase id, can be added by lain config save")
     @arg('procname', help="proc name of the app")
     @arg('path', help='absolute path of config file, eg : /lain/app/config')
-    def delete(cls, phase, procname, path):
+    @arg('-c', '--config', help="the configuration file path")
+    def delete(cls, phase, procname, path, config=LAIN_YAML_PATH):
         """
         delete secret file for different phase
         """
 
         check_phase(phase)
-        yml = lain_yaml(ignore_prepare=True)
+        yml = lain_yaml(config, ignore_prepare=True)
         authorize_and_check(phase, yml.appname)
         auth_header = get_auth_header(SSOAccess.get_token(phase))
         proc = yml.procs.get(procname, None)

--- a/lain_cli/tag.py
+++ b/lain_cli/tag.py
@@ -3,18 +3,19 @@ from argh.decorators import arg
 
 import lain_sdk.mydocker as docker
 from lain_sdk.util import error, info
-from lain_cli.utils import check_phase, lain_yaml, get_domain
+from lain_cli.utils import check_phase, lain_yaml, get_domain, LAIN_YAML_PATH
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
-def tag(phase):
+@arg('-c', '--config', help="the configuration file path")
+def tag(phase, config=LAIN_YAML_PATH):
     """
     Tag release and meta images
     """
 
     check_phase(phase)
     info("Taging meta and relese image ...")
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     meta_version = yml.repo_meta_version()
     if meta_version is None:
         error("please git commit.")

--- a/lain_cli/test.py
+++ b/lain_cli/test.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 import sys
-from lain_cli.utils import lain_yaml
+from argh.decorators import arg
+
+from lain_cli.utils import lain_yaml, LAIN_YAML_PATH
 
 
-def test():
+@arg('-c', '--config', help="the configuration file path")
+def test(config=LAIN_YAML_PATH):
     """
     Build test image and run test scripts defined in lain.yaml
     """
 
-    if not lain_yaml().build_test()[0]:
+    if not lain_yaml(config).build_test()[0]:
         sys.exit(1)
     else:
         sys.exit(0)

--- a/lain_cli/undeploy.py
+++ b/lain_cli/undeploy.py
@@ -4,19 +4,20 @@ from argh.decorators import arg
 
 from lain_sdk.util import error, warn, info
 from lain_cli.auth import SSOAccess, get_auth_header, authorize_and_check
-from lain_cli.utils import check_phase, get_domain, lain_yaml
+from lain_cli.utils import check_phase, get_domain, lain_yaml, LAIN_YAML_PATH
 
 
 @arg('phase', help="lain cluster phase id, can be added by lain config save")
 @arg('-t', '--target', help='The target app to deploy, if not set, will be the appname of the working dir')
 @arg('-p', '--proc', help='The proc wanted to undeploy')
-def undeploy(phase, target=None, proc=None):
+@arg('-c', '--config', help="the configuration file path")
+def undeploy(phase, target=None, proc=None, config=LAIN_YAML_PATH):
     """
     Undeploy specific proc in the app or the whole app
     """
 
     check_phase(phase)
-    yml = lain_yaml(ignore_prepare=True)
+    yml = lain_yaml(config, ignore_prepare=True)
     appname = target if target else yml.appname
     authorize_and_check(phase, appname)
 

--- a/lain_cli/utils.py
+++ b/lain_cli/utils.py
@@ -41,20 +41,20 @@ class TwoLevelCommandBase(object):
         '''return help message string'''
 
 
-def lain_yaml_data():
-    if not os.path.exists(LAIN_YAML_PATH):
-        error('Missing lain.yaml under current directory')
+def lain_yaml_data(config):
+    if not os.path.exists(config):
+        error('%s does not exist.' % config)
         sys.exit(1)
-    with open(LAIN_YAML_PATH) as f:
+    with open(config) as f:
         data = f.read()
     return yaml.load(data)
 
 
-def lain_yaml(ignore_prepare=False):
-    if not os.path.exists(LAIN_YAML_PATH):
-        error('Missing lain.yaml under current directory')
+def lain_yaml(config, ignore_prepare=False):
+    if not os.path.exists(config):
+        error('%s does not exist.' % config)
         sys.exit(1)
-    return LainYaml(LAIN_YAML_PATH, ignore_prepare=ignore_prepare)
+    return LainYaml(config, ignore_prepare=ignore_prepare)
 
 
 def check_phase(phase):
@@ -73,8 +73,8 @@ def get_domain(phase):
     return domain
 
 
-def get_apptype():
-    with open(LAIN_YAML_PATH, 'r') as f:
+def get_apptype(config):
+    with open(config, 'r') as f:
         y = yaml.safe_load(f.read())
     return y.get('apptype', 'app')
 

--- a/lain_cli/validate.py
+++ b/lain_cli/validate.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
 import sys
-from utils import lain_yaml_data, lain_yaml
+from argh.decorators import arg
+
+from utils import lain_yaml_data, lain_yaml, LAIN_YAML_PATH
 from lain_sdk.util import error, info, warn
 from lain_sdk.yaml.validator import validate as sdk_validate
 
 
-def _validate():
-    if _exist_same_procname_for_depends():
+def _validate(config):
+    if _exist_same_procname_for_depends(config):
         return False, 'procname of the depended services and resources should be different'
 
-    yaml_source_data = lain_yaml_data()
+    yaml_source_data = lain_yaml_data(config)
     return sdk_validate(yaml_source_data)
 
 
-def _exist_same_procname_for_depends():
-    yml = lain_yaml(ignore_prepare=True)
+def _exist_same_procname_for_depends(config):
+    yml = lain_yaml(config, ignore_prepare=True)
 
     service_procs, resource_procs = [], []
     if hasattr(yml, 'use_services'):
@@ -33,26 +35,27 @@ def _exist_same_procname_for_depends():
     return len(commons) < len(service_procs) + len(resource_procs)
 
 
-def validate_only_warning():
-    valid, _ = _validate()
+def validate_only_warning(config):
+    valid, _ = _validate(config)
     if not valid:
         error('##############################')
-        error('#  maybe invalid lain.yaml   #')
+        error('#  maybe invalid %s          #' % config)
         error('#  check the schema with     #')
         error('#    lain validate           #')
         error('##############################')
 
 
-def validate():
+@arg('--config',  help="the configuration file path")
+def validate(config=LAIN_YAML_PATH):
     """
-    Validate lain.yaml
+    Validate config
     """
 
-    valid, msg = _validate()
+    valid, msg = _validate(config)
     if valid:
-        info('valid lain.yaml.')
+        info('valid %s.' % config)
     else:
-        error('invalid lain.yaml.')
+        error('invalid %s.' % config)
         warn('error message:')
         info(msg)
         # TODO : show related doc url


### PR DESCRIPTION
## 起因

目前 lain-cli 使用 `./lain.yaml` 作为配置文件，然后可以通过 `LAIN_DOMAIN` 控制在不同集群下的行为。但这种方式存在一定的局限性：
- 开发者可能习惯于为不同的集群指定不同的配置文件，并不了解 `LAIN_DOMAIN` 这个环境变量
- 比如一个 maven 工程，必须编译两次（`mvn clean package -Pprod && mv /lain/app/target/demo.war /lain/app/demo-prod.war` 和 `mvn clean package -Pdev && mv /lain/app/target/demo.war /lain/app/demo-dev.war`），然后在 entry.sh 里指定要运行的 war 文件，而编译可能需要花不少时间
- 比如在测试环境里使用了 mysql-service，但生产环境直接用物理机上的 mysql，不使用 service 机制，`LAIN_DOMAIN` 无法做到这个层面的控制

使用不同的配置文件可以让开发者更容易理解，也更灵活

## 经过

在继续使用 `./lain.yaml` 作为默认配置文件的同时，也提供 `--config` 选项，让开发者可以自己指定配置文件。

## 结果

- `lain build -c lain-dev.yaml` 成功
- `lain tag dev` 成功
- `lain push dev` 成功
- `lain deploy dev` 成功